### PR TITLE
hot-fix/sk/style-change

### DIFF
--- a/YOGO/src/components/atoms/Title/style.tsx
+++ b/YOGO/src/components/atoms/Title/style.tsx
@@ -9,6 +9,6 @@ export const Text = styled.Text<ITitleProps>`
   color: ${props => (props.isEnable ? '#000000' : '#999999')};
   font-size: ${props => props.size};
   font-weight: bold;
-  margin-bottom: 5;
-  text-align: center;
+
+  margin-bottom: 20px;
 `;

--- a/YOGO/src/components/molecules/TagSelectContainer/style.tsx
+++ b/YOGO/src/components/molecules/TagSelectContainer/style.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components/native";
+import styled from 'styled-components/native';
 
 export const Container = styled.View`
   width: 100%;
@@ -10,11 +10,10 @@ export const Container = styled.View`
 `;
 
 export const Wrapper = styled.View`
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-    align-items: ;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
 
-    margin-top: 15px;
-`
+  margin-top: 15px;
+`;


### PR DESCRIPTION
## Summary

- [X] 타이틀이 중앙 정렬 되었던 부분 수정

<img width="363" alt="스크린샷 2022-05-07 오전 11 24 20" src="https://user-images.githubusercontent.com/60822846/167234247-97754506-e3fa-4efc-baab-a01fc64fd462.png">

위 부분 타이틀이 중앙정렬 되었던 부분을 왼쪽 배치
